### PR TITLE
Attempt at update pack.co; please read the description

### DIFF
--- a/src/generate/pack.co
+++ b/src/generate/pack.co
@@ -18,6 +18,88 @@ genPack = (setName) ->
     special = if rand 20 then <>gate else <>shock
   case 'Modern Masters'
     special = []concat common, uncommon, rare
+  case 'Portal'
+    special = []concat common
+  case 'Portal Second Age'
+    special = []concat common
+  case 'Fourth Edition'
+    special = []concat common
+  case 'Fifth Edition'
+    special = []concat common
+  case 'Classic Sixth Edition'
+    special = []concat common
+  case 'Mirage'
+    special = []concat common
+  case 'Visions'
+    special = []concat common
+  case 'Weatherlight'
+    special = []concat common
+  case 'Tempest'
+    special = []concat common
+  case 'Stronghold'
+    special = []concat common
+  case 'Exodus'
+    special = []concat common
+  case "Urza's Saga"
+    special = []concat common
+  case "Urza's Legacy"
+    special = []concat common
+  case "Urza's Destiny"
+    special = []concat common
+  case 'Mercadian Masques'
+    special = []concat common
+  case 'Nemesis'
+    special = []concat common
+  case 'Prophecy'
+    special = []concat common
+  case 'Invasion'
+    special = []concat common
+  case 'Planeshift'
+    special = []concat common
+  case 'Apocalypse'
+    special = []concat common
+  case 'Odyssey'
+    special = []concat common
+  case 'Torment'
+    special = []concat common
+  case 'Judgment'
+    special = []concat common
+  case 'Onslaught'
+    special = []concat common
+  case 'Legions'
+    special = []concat common
+  case 'Scourge'
+    special = []concat common
+  case 'Mirrodin'
+    special = []concat common
+  case 'Darksteel'
+    special = []concat common
+  case 'Fifth Dawn'
+    special = []concat common
+  case 'Champions of Kamigawa'
+    special = []concat common
+  case 'Betrayers of Kamigawa'
+    special = []concat common
+  case 'Saviors of Kamigawa'
+    special = []concat common
+  case 'Ravnica: City of Guilds'
+    special = []concat common
+  case 'Guildpact'
+    special = []concat common
+  case 'Dissension'
+    special = []concat common
+  case 'Future Sight'
+    special = []concat common
+  case 'Coldsnap'
+    special = []concat common
+  case 'Lorwyn'
+    special = []concat common
+  case 'Morningtide'
+    special = []concat common
+  case 'Shadowmoor'
+    special = []concat common
+  case 'Eventide'
+    special = []concat common
 
   if special
     index = rand special.length


### PR DESCRIPTION
I have NO knowledge of coffeescript or javascript, so all this code can be entirely rubbish, as it is just a shot in the dark. Still, here’s an attempt.

As it is known, several editions had boosters of varying contents, rarity- and card number-wise. The draft program gives a default of 14 cards per pack, however a lot of older editions had 15 cards (one additional common). This is a difference that can sometimes have some impact on the resulting decks (the 15th card received occasionally being a niche sideboard card that got actually used during a match).

This attempts to alleviate the problem, by replacing the blank special card with an additional common in a number of MtG expansions, according to this: http://wiki.mtgsalvation.com/article/Booster_pack

I left the oldest expansions (Alpha, Beta, Unlimited, Revised) alone, as well as those that didn’t follow the 15 card (11C, 3U, 1R) model.

As a final remark, I can’t find any code regarding Time Spiral here, which however seems to generate appropriate boosters (15 cards: 10C, 3U, 1R, 1 timeshifted). This suggests that this place isn’t the only code affecting pack generation… But I couldn’t find anything else.

I also left alone Planar Chaos — it needs a modification, as it also should generate 15 card boosters, however the issues with its timeshifted sheet are quite over my head.
