### PR TITLE
Fixed issue where kicking from a draft did nothing.

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -106,6 +106,7 @@ module.exports = class Game extends Room {
       h.kick()
     else
       h.exit()
+    this.meta()
 
     h.err('you were kicked')
   }


### PR DESCRIPTION
Previously, kicking a player from an already-running draft didn't actually seem to do anything. Now kicking them causes them to act like a bot, as expected.
