### PR TITLE
Sort cards by color and CMC before name

### DIFF
--- a/public/src/cards.js
+++ b/public/src/cards.js
@@ -274,7 +274,7 @@ export function getZone(zoneName) {
   let {sort} = App.state
   let groups = _.group(cards, sort)
   for (let key in groups)
-    _.sort(groups[key], 'name')
+    _.sort(groups[key], 'color', 'cmc', 'name')
 
   groups = Key(groups, sort)
 


### PR DESCRIPTION
Changed the sort to match the way I usually see people organizing their
cards when deck building.

This depends on https://github.com/aeosynth/utils/pull/1