### PR TITLE
FRF Land Slots may contain fetches, KTK taplands and basic lands

### DIFF
--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -46,8 +46,7 @@ function before() {
       card.rarity = 'special'
 
   for (card of raw.FRF.cards)
-    // Includes all possible lands except Crucible of Spirit Dragon, the only rare land.
-    if ((/Land/.test(card.type)) && (!(/Rare/.test(card.rarity))))
+    if (/Land/.test(card.type) && (card.name !== 'Crucible of the Spirit Dragon'))
       card.rarity = 'special'
 
   //http://mtgsalvation.gamepedia.com/Magic_2015/Sample_decks

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -83,13 +83,7 @@ function after() {
 
   var {FRF} = Sets
   FRF.special = {
-    common: [
-      ...FRF.special,
-      'plains',
-      'island',
-      'swamp',
-      'mountain',
-      'forest'],
+    common: FRF.special,
     fetch: [
       'flooded strand',
       'bloodstained mire',

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -63,6 +63,10 @@ function after() {
     Cards[lc].sets.pHHO.url = `http://mtgimage.com/card/${name}.jpg`
   }
 
+  for (var card of raw.FRF.cards)
+    if (rarity === 'basic')
+      rarity = 'special'
+    
   var {DGM} = Sets
   DGM.special = {
     gate: DGM.special,
@@ -140,7 +144,7 @@ function doSet(rawSet, code) {
 
 function doCard(rawCard, cards, code, set) {
   var rarity = rawCard.rarity.split(' ')[0].toLowerCase()
-  if ((rarity === 'basic') && !(code === 'FRF'))
+  if (rarity === 'basic')
     return
 
   var {name} = rawCard

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -84,7 +84,7 @@ function after() {
 
   var {FRF} = Sets
   FRF.special = {
-    common: DGM.special,
+    common: FRF.special,
     fetch: [
       'flooded strand',
       'bloodstained mire',

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -45,6 +45,11 @@ function before() {
       || /draft/.test(card.text))
       card.rarity = 'special'
 
+  for (card of raw.FRF.cards)
+    // Includes all possible lands except Crucible of Spirit Dragon, the only rare land.
+    if ((/Land/.test(card.type)) && (!(/Rare/.test(card.rarity)))
+      card.rarity = 'special'
+
   //http://mtgsalvation.gamepedia.com/Magic_2015/Sample_decks
   // Each sample deck has several cards numbered 270 and higher that do not
   // appear in Magic 2015 booster packs.
@@ -74,6 +79,18 @@ function after() {
       'temple garden',
       'watery grave',
       'maze\'s end'
+    ]
+  }
+
+  var {FRF} = Sets
+  FRF.special = {
+    common: DGM.special,
+    fetch: [
+      'flooded strand',
+      'bloodstained mire',
+      'wooded foothills',
+      'windswept heath',
+      'polluted delta',
     ]
   }
 
@@ -124,7 +141,7 @@ function doSet(rawSet, code) {
 
 function doCard(rawCard, cards, code, set) {
   var rarity = rawCard.rarity.split(' ')[0].toLowerCase()
-  if (rarity === 'basic')
+  if ((rarity === 'basic') && !(code === 'FRF'))
     return
 
   var {name} = rawCard

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -84,7 +84,7 @@ function after() {
   var {FRF} = Sets
   FRF.special = {
     common: [
-      FRF.special,
+      ...FRF.special,
       'plains',
       'island',
       'swamp',

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -47,7 +47,7 @@ function before() {
 
   for (card of raw.FRF.cards)
     // Includes all possible lands except Crucible of Spirit Dragon, the only rare land.
-    if ((/Land/.test(card.type)) && (!(/Rare/.test(card.rarity)))
+    if ((/Land/.test(card.type)) && (!(/Rare/.test(card.rarity))))
       card.rarity = 'special'
 
   //http://mtgsalvation.gamepedia.com/Magic_2015/Sample_decks

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -63,10 +63,6 @@ function after() {
     Cards[lc].sets.pHHO.url = `http://mtgimage.com/card/${name}.jpg`
   }
 
-  for (var card of raw.FRF.cards)
-    if (rarity === 'basic')
-      rarity = 'special'
-    
   var {DGM} = Sets
   DGM.special = {
     gate: DGM.special,
@@ -87,7 +83,13 @@ function after() {
 
   var {FRF} = Sets
   FRF.special = {
-    common: FRF.special,
+    common: [
+      FRF.special,
+      'plains',
+      'island',
+      'swamp',
+      'mountain',
+      'forest'],
     fetch: [
       'flooded strand',
       'bloodstained mire',

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -100,6 +100,13 @@ function after() {
     var last = codes[codes.length - 1]
     sets.DGM = sets[last]
   }
+
+  for (var cardName of FRF.special.fetch) {
+    var {sets} = Cards[cardName]
+    var codes = Object.keys(sets)
+    var last = codes[codes.length - 1]
+    sets.FRF = sets[last]
+  }
 }
 
 function doSet(rawSet, code) {

--- a/src/pool.js
+++ b/src/pool.js
@@ -39,6 +39,12 @@ function toPack(code) {
     if (_.rand(53))
       special = selectRarity(set)
     break
+  case 'FRF':
+  // Same with DGM
+    special = _.rand(20)
+      ? special.common
+      : special.fetch
+    break     
   }
 
   if (special)

--- a/src/pool.js
+++ b/src/pool.js
@@ -40,7 +40,6 @@ function toPack(code) {
       special = selectRarity(set)
     break
   case 'FRF':
-  // Same with DGM
     special = _.rand(20)
       ? special.common
       : special.fetch


### PR DESCRIPTION
Thus, when cards are being scraped, basic lands will be included in FRF set as 'special' rarity along with KTK taplands.

Everything else is same as how it was done with DGM set.