### PR TITLE
Force chat scroll after render

### DIFF
--- a/public/src/components/chat.js
+++ b/public/src/components/chat.js
@@ -28,8 +28,13 @@ export default React.createClass({
 
   hear(msg) {
     this.state.messages.push(msg)
-    this.forceUpdate()
-    this.getDOMNode().firstChild.lastChild.scrollIntoView()
+    this.forceUpdate(
+      () => {
+        let el = document.getElementById('messages')
+        el.scrollTop = el.scrollHeight
+      }
+    )
+    // document.getElementById('messages').lastChild.scrollIntoView()
   },
   Message(msg) {
     if (!msg)

--- a/public/src/components/chat.js
+++ b/public/src/components/chat.js
@@ -21,7 +21,7 @@ export default React.createClass({
     // must be mounted to receive messages
     let {hidden} = this.props
     return d.div({ hidden, id: 'chat' },
-      d.div({ id: 'messages' , ref: 'messages'},
+      d.div({ id: 'messages', ref: 'messages'},
         this.state.messages.map(this.Message)),
       this.Entry())
   },

--- a/public/src/components/chat.js
+++ b/public/src/components/chat.js
@@ -34,7 +34,6 @@ export default React.createClass({
         el.scrollTop = el.scrollHeight
       }
     )
-    // document.getElementById('messages').lastChild.scrollIntoView()
   },
   Message(msg) {
     if (!msg)

--- a/public/src/components/chat.js
+++ b/public/src/components/chat.js
@@ -28,12 +28,11 @@ export default React.createClass({
 
   hear(msg) {
     this.state.messages.push(msg)
-    this.forceUpdate(
-      () => {
-        let el = document.getElementById('messages')
-        el.scrollTop = el.scrollHeight
-      }
-    )
+    this.forceUpdate(this.scrollChat)
+  },
+  scrollChat() {
+    let el = document.getElementById('messages')
+    el.scrollTop = el.scrollHeight
   },
   Message(msg) {
     if (!msg)
@@ -105,6 +104,6 @@ export default React.createClass({
       time: Date.now(),
       name: ''
     })
-    this.forceUpdate()
+    this.forceUpdate(this.scrollChat)
   }
 })

--- a/public/src/components/chat.js
+++ b/public/src/components/chat.js
@@ -21,7 +21,7 @@ export default React.createClass({
     // must be mounted to receive messages
     let {hidden} = this.props
     return d.div({ hidden, id: 'chat' },
-      d.div({ id: 'messages' },
+      d.div({ id: 'messages' , ref: 'messages'},
         this.state.messages.map(this.Message)),
       this.Entry())
   },
@@ -31,7 +31,7 @@ export default React.createClass({
     this.forceUpdate(this.scrollChat)
   },
   scrollChat() {
-    let el = document.getElementById('messages')
+    let el = this.refs.messages.getDOMNode()
     el.scrollTop = el.scrollHeight
   },
   Message(msg) {

--- a/public/src/components/chat.js
+++ b/public/src/components/chat.js
@@ -29,6 +29,7 @@ export default React.createClass({
   hear(msg) {
     this.state.messages.push(msg)
     this.forceUpdate()
+    this.getDOMNode().firstChild.lastChild.scrollIntoView()
   },
   Message(msg) {
     if (!msg)


### PR DESCRIPTION
So I'm not too familiar with ES6 or React yet, but I saw this issue and it seemed relatively simple to fix.
~~My solution involves getting the DOMNode which is the chat element, then the first child of that which is the messages div, and the last child of that which is the latest message to be received.

This could probably be shortcut if we have a handle on the message div at some point.

I thought it may be in render, but then saw that it is rendering the entirety of the messages after every message.~~

Using refs to grab the messages div and scroll it.

https://github.com/aeosynth/draft/issues/103