### PR TITLE
Fix missing Lightning Bolt rarity in spoiler

### DIFF
--- a/src/make/spoiler/mtgs.js
+++ b/src/make/spoiler/mtgs.js
@@ -18,12 +18,16 @@ function parse() {
     .attr('class')
     .match(/\w+$/)[0]
 
-  if (rarity === 'land' || rarity === 'unknown')
-    return
-
   let name = $el.attr('id')
   let url = images[name]
   if (!url)
+    return
+
+  /* Hack to fix unknown rarity in MM2 spoiler */
+  if (name === 'Lightning Bolt')
+    rarity = 'uncommon'
+
+  if (rarity === 'land' || rarity === 'unknown')
     return
 
   let type = $el


### PR DESCRIPTION
The MTGS spoiler doesn't have a rarity on Lightning Bolt, so it doesn't get imported when you `make spoiler`.

Fixes issue #122.