### PR TITLE
Syntax update update

### DIFF
--- a/src/pool.js
+++ b/src/pool.js
@@ -32,6 +32,8 @@ function toPack(code) {
     _.choose(1, rare)
   )
 
+  let specialrnd
+
   switch (code) {
   case 'DGM':
     special = _.rand(20)
@@ -57,7 +59,7 @@ function toPack(code) {
   case 'ISD':
   //http://www.mtgsalvation.com/forums/magic-fundamentals/magic-general/327956-innistrad-block-transforming-card-pack-odds?comment=4
   //121 card sheet, 1 mythic, 12 rare (13), 42 uncommon (55), 66 common
-    let specialrnd = _.rand(121)
+    specialrnd = _.rand(121)
     if (specialrnd == 0)
       special = special.mythic
     else if (specialrnd < 13)
@@ -70,7 +72,7 @@ function toPack(code) {
   case 'DKA':
   //http://www.mtgsalvation.com/forums/magic-fundamentals/magic-general/327956-innistrad-block-transforming-card-pack-odds?comment=4
   //80 card sheet, 2 mythic, 6 rare (8), 24 uncommon (32), 48 common
-    let specialrnd = _.rand(80)
+    specialrnd = _.rand(80)
     if (specialrnd <= 1)
       special = special.mythic
     else if (specialrnd < 8)


### PR DESCRIPTION
Previously, an attempt to run `node app.js` would fail with this
mysterious and wholly unhelpful error:

```
undefined:24786
        throw errorReporter.errors;
        ^
<compile-source>:73:9: Duplicate declaration, specialrnd
```

Evidently, a declaration is duplicated if it is made across case bodies.
