### PR TITLE
Autopick

### DIFF
--- a/public/src/cards.js
+++ b/public/src/cards.js
@@ -226,13 +226,10 @@ function clickPack(cardName) {
     // There may be duplicate cards in a pack, but only one copy of a card is
     // shown in the pick view. We must be sure to mark them all since we don't
     // know which one is being displayed.
-    rawPack.forEach(card => card.isSelected = card.name == cardName);
+    rawPack.forEach(card => card.isAutopick = card.name === cardName)
     App.update()
+    App.send('autopick', index)
     return clicked
-  } else if (card.hasOwnProperty('isSelected')) {
-    // Don't leave the is-selected overlay when moving the card to a different
-    // zone.
-    delete card['isSelected']
   }
 
   clicked = null

--- a/public/src/cards.js
+++ b/public/src/cards.js
@@ -218,10 +218,23 @@ function cube() {
 }
 
 function clickPack(cardName) {
-  if (clicked !== cardName)
-    return clicked = cardName
-
   let index = rawPack.findIndex(x => x.name === cardName)
+  let card = rawPack[index]
+
+  if (clicked !== cardName) {
+    clicked = cardName
+    // There may be duplicate cards in a pack, but only one copy of a card is
+    // shown in the pick view. We must be sure to mark them all since we don't
+    // know which one is being displayed.
+    rawPack.forEach(card => card.isSelected = card.name == cardName);
+    App.update()
+    return clicked
+  } else if (card.hasOwnProperty('isSelected')) {
+    // Don't leave the is-selected overlay when moving the card to a different
+    // zone.
+    delete card['isSelected']
+  }
+
   clicked = null
   Zones.pack = {}
   App.update()

--- a/public/src/components/grid.js
+++ b/public/src/components/grid.js
@@ -15,11 +15,13 @@ function zone(zoneName) {
   let values = _.values(zone)
   let cards = _.flat(values)
 
+  let isAutopickable = card => zoneName === 'pack' && card.isAutopick
+
   let items = cards.map(card =>
     d.span(
       {
-        className: card.isSelected ? 'selected-card' : 'unselected-card',
-        title: card.isSelected ? 'This card will be automatically picked if your time expires.' : '',
+        className: `card ${isAutopickable(card) ? 'autopick-card' : ''}`,
+        title: isAutopickable(card) ? 'This card will be automatically picked if your time expires.' : '',
         onClick: App._emit('click', zoneName, card.name),
       },
       d.img({

--- a/public/src/components/grid.js
+++ b/public/src/components/grid.js
@@ -16,11 +16,16 @@ function zone(zoneName) {
   let cards = _.flat(values)
 
   let items = cards.map(card =>
-    d.img({
-      onClick: App._emit('click', zoneName, card.name),
-      src: card.url,
-      alt: card.name
-    }))
+    d.span(
+      {
+        className: card.isSelected ? 'selected-card' : 'unselected-card',
+        title: card.isSelected ? 'This card will be automatically picked if your time expires.' : '',
+        onClick: App._emit('click', zoneName, card.name),
+      },
+      d.img({
+        src: card.url,
+        alt: card.name,
+      })))
 
   return d.div({ className: 'zone' },
     d.h1({}, `${zoneName} ${cards.length}`),

--- a/public/style.css
+++ b/public/style.css
@@ -39,6 +39,51 @@ time {
   color: white;
 }
 
+/* Tint the card blue when selected. */
+.selected-card, .unselected-card {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+  cursor: pointer;
+}
+
+.selected-card:before, .unselected-card:hover:before {
+  content: '';
+
+  display: block;
+  position: absolute;
+
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  margin-bottom: 5px;
+  border-radius: 12px;
+
+  background: rgba(200, 200, 200, 0.25);
+}
+
+.selected-card:after {
+  content: 'Autopick';
+
+  display: inline-block;
+  position: absolute;
+
+  /* Center in the middle of the bottom border on the card. */
+  line-height: 25px;
+  bottom: 5px;
+  left: 0;
+  right: 0;
+
+  color: #fff;
+  font-family: Verdana, Arial, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  text-align: center;
+  text-shadow: 0px 0px 2px #000;
+}
+
 .error {
   color: red;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -39,15 +39,14 @@ time {
   color: white;
 }
 
-/* Tint the card blue when selected. */
-.selected-card, .unselected-card {
+.card {
   display: inline-block;
   position: relative;
   margin: 0;
   cursor: pointer;
 }
 
-.selected-card:before, .unselected-card:hover:before {
+.card:hover:before, .autopick-card:before {
   content: '';
 
   display: block;
@@ -64,7 +63,7 @@ time {
   background: rgba(200, 200, 200, 0.25);
 }
 
-.selected-card:after {
+.autopick-card:after {
   content: 'Autopick';
 
   display: inline-block;

--- a/src/game.js
+++ b/src/game.js
@@ -17,7 +17,7 @@ var games = {}
       continue
     for (var p of game.players)
       if (p.time && !--p.time)
-        p.pickRand()
+        p.pickOnTimeout()
   }
   setTimeout(playerTimer, SECOND)
 })()

--- a/src/pool.js
+++ b/src/pool.js
@@ -32,6 +32,8 @@ function toPack(code) {
     _.choose(1, rare)
   )
 
+  let specialrnd
+
   switch (code) {
   case 'DGM':
     special = _.rand(20)
@@ -57,7 +59,7 @@ function toPack(code) {
   case 'ISD':
   //http://www.mtgsalvation.com/forums/magic-fundamentals/magic-general/327956-innistrad-block-transforming-card-pack-odds?comment=4
   //121 card sheet, 1 mythic, 12 rare (13), 42 uncommon (55), 66 common
-    let specialrnd = _.rand(121)
+    specialrnd = _.rand(121)
     if (specialrnd == 0)
       special = special.mythic
     else if (specialrnd < 13)
@@ -70,7 +72,7 @@ function toPack(code) {
   case 'DKA':
   //http://www.mtgsalvation.com/forums/magic-fundamentals/magic-general/327956-innistrad-block-transforming-card-pack-odds?comment=4
   //80 card sheet, 2 mythic, 6 rare (8), 24 uncommon (32), 48 common
-    let specialrnd = _.rand(80)
+    specialrnd = _.rand(80)
     if (specialrnd <= 1)
       special = special.mythic
     else if (specialrnd < 8)


### PR DESCRIPTION
This PR is based on top of https://github.com/aeosynth/draft/pull/149.

This PR implements 'autopicking' functionality. When the user selects a card, it is reserved as the autopick card. If the user's time expires, that card is picked, instead of a random card. Closes #55.

The new interface looks like this:

<img width="1548" alt="screen shot 2016-05-11 at 14 19 02" src="https://cloud.githubusercontent.com/assets/454057/15191592/53062b30-1783-11e6-8e26-e13c811f90dd.png">

_Depicted: Ruin Processor is selected as the autopick card, triggered by clicking it once. The mouse cursor is over Kor Entanglers, so it is highlighted. When time expires, Ruin Processor will automatically be selected._
