### PR TITLE
Suggest lands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
+.PHONY: all install clean cards score js
 all: install clean cards score js
 
 node := ${CURDIR}/node_modules
+all_sets := ${CURDIR}/data/AllSets.json
+traceur := ${node}/.bin/traceur
+
+${traceur}: install
 
 install:
 	npm install
@@ -14,22 +19,22 @@ install:
 	ln -sf ${node}/utils/utils.js public/lib
 
 clean:
-	rm -f data/AllSets.json
+	rm -f ${all_sets}
 
-cards: data/AllSets.json
+cards: ${all_sets}
 	node src/make cards
 
 custom:
 	node src/make custom
 
-data/AllSets.json:
-	curl -so data/AllSets.json https://mtgjson.com/json/AllSets.json
+${all_sets}:
+	curl -so ${all_sets} https://mtgjson.com/json/AllSets.json
 
 score:
 	-node src/make score #ignore errors
 
-js:
-	node_modules/.bin/traceur --out public/lib/app.js public/src/init.js
+js: ${traceur} ${all_sets}
+	${traceur} --out public/lib/app.js public/src/init.js
 
 run: js
 	node run

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -33,6 +33,7 @@ let App = {
     beep: false,
     chat: true,
     cols: false,
+    deckSize: 40,
     filename: 'filename',
     filetype: 'txt',
     side: false,

--- a/public/src/components/settings.js
+++ b/public/src/components/settings.js
@@ -24,12 +24,28 @@ function Lands() {
       inputs)
   })
 
+  let suggest = d.tr({},
+    d.td({}, 'deck size'),
+    d.td({}, d.input({
+      min: 0,
+      onChange: App._emit('deckSize'),
+      type: 'number',
+      value: App.state.deckSize,
+    })),
+    d.td({ colSpan: 2 }, d.button({
+      onClick: App._emit('resetLands')
+    }, 'reset lands')),
+    d.td({colSpan: 2 }, d.button({
+      onClick: App._emit('suggestLands')
+    }, 'suggest lands')))
+
   return d.table({},
     d.tr({},
       d.td(),
       symbols),
     main,
-    side)
+    side,
+    suggest)
 }
 
 function Sort() {

--- a/src/make/cards.js
+++ b/src/make/cards.js
@@ -245,6 +245,7 @@ function doCard(rawCard, cards, code, set) {
     colors[0].toLowerCase()
 
   cards[name] = { color, name,
+    manaCost: rawCard.manaCost,
     type: rawCard.types[rawCard.types.length - 1],
     cmc: rawCard.cmc || 0,
     sets: {

--- a/src/pool.js
+++ b/src/pool.js
@@ -32,6 +32,8 @@ function toPack(code) {
     _.choose(1, rare)
   )
 
+  let specialrnd
+
   switch (code) {
   case 'DGM':
     special = _.rand(20)
@@ -57,7 +59,7 @@ function toPack(code) {
   case 'ISD':
   //http://www.mtgsalvation.com/forums/magic-fundamentals/magic-general/327956-innistrad-block-transforming-card-pack-odds?comment=4
   //121 card sheet, 1 mythic, 12 rare (13), 42 uncommon (55), 66 common
-    let specialrnd = _.rand(121)
+    specialrnd = _.rand(121)
     if (specialrnd == 0)
       special = special.mythic
     else if (specialrnd < 13)
@@ -70,7 +72,7 @@ function toPack(code) {
   case 'DKA':
   //http://www.mtgsalvation.com/forums/magic-fundamentals/magic-general/327956-innistrad-block-transforming-card-pack-odds?comment=4
   //80 card sheet, 2 mythic, 6 rare (8), 24 uncommon (32), 48 common
-    let specialrnd = _.rand(80)
+    specialrnd = _.rand(80)
     if (specialrnd <= 1)
       special = special.mythic
     else if (specialrnd < 8)


### PR DESCRIPTION
This PR implements a reasonably effective land suggestion feature. Fixes #54. The controls look like this:

<img width="389" alt="screen shot 2016-05-14 at 18 22 15" src="https://cloud.githubusercontent.com/assets/454057/15271483/3b207ffe-1a01-11e6-86b2-56e7e2c1dd52.png">

For example, a deck with 10 white cards, 11 blue cards, and 2 black cards gets 7 Plains, 7 Islands, and 3 Swamps.

This PR also fixes the Makefile dependencies, which previously weren't set up correctly so as to be able to parallelize its build.
